### PR TITLE
CB-835965 fix value type problem when using moodle csv upload

### DIFF
--- a/classes/data_controller.php
+++ b/classes/data_controller.php
@@ -122,7 +122,7 @@ class data_controller extends \core_customfield\data_controller {
             return;
         }
         $value = $datanew->$elementname;
-        if ($this->get_field()->get_configdata_property('multiselect')) {
+        if ($this->get_field()->get_configdata_property('multiselect') && is_array($value)) {
             $value = implode(',', $datanew->$elementname);
         }
 


### PR DESCRIPTION
the function do not receive an array when upload a course uploads csv. this allows the user to enter comma separated ids in the uploaded csv.